### PR TITLE
Feat/CU-86a2cw9z9: add heading and texts components

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -4,29 +4,20 @@
     "browser": true,
     "es2020": true
   },
-  "extends": [
-    "airbnb",
-    "airbnb-typescript",
-    "airbnb/hooks",
-    "plugin:prettier/recommended"
-  ],
-  "ignorePatterns": [
-    "dist",
-    "vite.config.ts"
-  ],
+  "extends": ["airbnb", "airbnb-typescript", "airbnb/hooks", "plugin:prettier/recommended"],
+  "ignorePatterns": ["dist", "vite.config.ts"],
   "parser": "@typescript-eslint/parser",
   "parserOptions": {
     "ecmaVersion": "latest",
     "sourceType": "module",
     "project": "./tsconfig.json"
   },
-  "plugins": [
-    "react"
-  ],
+  "plugins": ["react"],
   "rules": {
     "no-console": "warn",
     "react/react-in-jsx-scope": "off",
     "@typescript-eslint/no-unused-vars": "error",
-    "import/extensions": "off"
+    "import/extensions": "off",
+    "react/require-default-props": "off"
   }
 }

--- a/index.html
+++ b/index.html
@@ -3,6 +3,12 @@
   <head>
     <meta charset="UTF-8" />
     <link rel="icon" type="image/png" href="/favicon.png" />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:ital,wght@0,200..800;1,200..800&display=swap"
+      rel="stylesheet"
+    />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Kanban task management</title>
   </head>

--- a/src/components/BaseHeading/BaseHeading.css
+++ b/src/components/BaseHeading/BaseHeading.css
@@ -1,0 +1,37 @@
+.base-heading {
+  font-family: 'Plus Jakarta Sans', sans-serif;
+  color: var(--color-black);
+}
+
+.base-heading--xl {
+  font-size: 24px;
+  line-height: 30px;
+}
+
+.base-heading--lg {
+  font-size: 18px;
+  line-height: 23px;
+}
+
+.base-heading--md {
+  font-size: 15px;
+  line-height: 19px;
+}
+
+.base-heading--sm {
+  font-size: 12px;
+  line-height: 15px;
+  kerning: 2.4px;
+}
+
+.base-heading--bold {
+  font-weight: bold;
+}
+
+.base-heading--medium {
+  font-weight: 500;
+}
+
+.base-heading--normal {
+  font-weight: normal;
+}

--- a/src/components/BaseHeading/BaseHeading.tsx
+++ b/src/components/BaseHeading/BaseHeading.tsx
@@ -1,0 +1,26 @@
+import './BaseHeading.css';
+
+interface BaseHeadingProps {
+  children?: React.ReactNode;
+  size?: 'xl' | 'lg' | 'md' | 'sm';
+  variant: 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6';
+  fontWeight?: 'bold' | 'medium' | 'normal';
+  className?: string;
+}
+
+function BaseHeading({
+  children,
+  size = 'md',
+  variant = 'h1',
+  fontWeight = 'normal',
+  className = ''
+}: BaseHeadingProps) {
+  const HeadingTag = `${variant}` as keyof JSX.IntrinsicElements;
+  return (
+    <HeadingTag className={`base-heading base-heading--${size} base-heading--${fontWeight} ${className}`}>
+      {children}
+    </HeadingTag>
+  );
+}
+
+export default BaseHeading;

--- a/src/components/BaseHeading/index.ts
+++ b/src/components/BaseHeading/index.ts
@@ -1,0 +1,3 @@
+import BaseHeading from './BaseHeading';
+
+export default BaseHeading;

--- a/src/components/BaseText/BaseText.css
+++ b/src/components/BaseText/BaseText.css
@@ -1,0 +1,26 @@
+.base-text {
+  font-family: 'Plus Jakarta Sans', sans-serif;
+  color: var(--color-dark-grey);
+}
+
+.base-text--lg {
+  font-size: 13px;
+  line-height: 23px;
+}
+
+.base-text--md {
+  font-size: 12px;
+  line-height: 19px;
+}
+
+.base-text--bold {
+  font-weight: bold;
+}
+
+.base-text--medium {
+  font-weight: 500;
+}
+
+.base-text--normal {
+  font-weight: normal;
+}

--- a/src/components/BaseText/BaseText.tsx
+++ b/src/components/BaseText/BaseText.tsx
@@ -1,0 +1,14 @@
+import './BaseText.css';
+
+interface BaseTextProps {
+  children: React.ReactNode;
+  size?: 'lg' | 'md';
+  className?: string;
+  fontWeight?: 'bold' | 'medium' | 'normal';
+}
+
+function BaseText({ size = 'md', fontWeight = 'normal', className = '', children }: BaseTextProps) {
+  return <p className={`base-text base-text--${size} base-text--${fontWeight} ${className}`}>{children}</p>;
+}
+
+export default BaseText;

--- a/src/components/BaseText/index.ts
+++ b/src/components/BaseText/index.ts
@@ -1,0 +1,3 @@
+import BaseText from './BaseText.tsx';
+
+export default BaseText;


### PR DESCRIPTION
## Descripción:

Implementar un conjunto de componentes de tipografía en React utilizando TypeScript que sean fieles a la guía de estilos provista en Figma.


## Cambios Realizados:

- [x] Se agrego el componente BaseHeading

- [x] Se agrego el componente BaseText

- [x] Se agrego una exepcion al eslint para las props

- [x] Se agrego la fuente del proyecto al index.html





