### PR TITLE
Feat/CU-86a21ppe: add BaseTextField component

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,12 +1,12 @@
 import { useState } from 'react';
-import reactLogo from './assets/react.svg';
 import './App.css';
 import BaseSelect from './components/BaseSelect';
 import { Option } from './components/BaseSelect/BaseSelect';
+import BaseTextField from './components/BaseTextField';
 
 function App() {
-  const [count, setCount] = useState(0);
   const [option, setOption] = useState<Option>();
+  const [text, setText] = useState('');
 
   const options = [
     { value: 'chocolate', label: 'Chocolate' },
@@ -17,21 +17,11 @@ function App() {
   return (
     <>
       <BaseSelect options={options} value={option} onSelect={setOption} />
-      <div>
-        <a href="https://react.dev" target="_blank" rel="noreferrer">
-          <img src={reactLogo} className="logo react" alt="React logo" />
-        </a>
-      </div>
-      <h1>Vite + React</h1>
-      <div className="card">
-        <button type="button" onClick={() => setCount((currentCount) => currentCount + 1)}>
-          count is {count}
-        </button>
-        <p>
-          Edit <code>src/App.tsx</code> and save to test HMR
-        </p>
-      </div>
-      <p className="read-the-docs">Click on the Vite and React logos to learn more</p>
+
+      <form>
+        <BaseTextField onChange={setText} value={text} label="Text Field" required placeholder="e.g Make cofee" />
+        <button type="submit">Submit</button>
+      </form>
     </>
   );
 }

--- a/src/components/BaseTextField/BaseTextField.css
+++ b/src/components/BaseTextField/BaseTextField.css
@@ -1,0 +1,78 @@
+.base-text-field {
+  display: flex;
+  align-items: flex-end;
+  gap: 8px;
+  width: 100%;
+}
+
+.base-text-field__body {
+  width: 100%;
+  display: flex;
+  gap: 8px;
+  flex-direction: column;
+}
+
+.base-text-field__error,
+.base-text-field__input,
+.base-text-field__label {
+  font-size: 13px;
+}
+
+.base-text-field__error,
+.base-text-field__input::placeholder,
+.base-text-field__input {
+  font-weight: 500;
+}
+
+.base-text-field__label {
+  text-align: left;
+  font-weight: bold;
+  color: var(--color-medium-grey);
+}
+
+.base-text-field__content {
+  border-radius: 4px;
+  border: 1px solid var(--color-medium-grey-o-25);
+  display: flex;
+  gap: 8px;
+  justify-content: space-between;
+  padding: 9px 16px;
+}
+
+.base-text-field__input {
+  border: none;
+  color: var(--color-black);
+  margin: 2px;
+  outline: none;
+  padding: 0;
+  width: 100%;
+}
+
+.base-text-field__input::placeholder {
+  color: var(--color-medium-grey);
+}
+
+.base-text-field__content:hover,
+.base-text-field--focused .base-text-field__content {
+  border-color: var(--color-main-purple);
+}
+
+.base-text-field__error {
+  width: 100%;
+  max-width: 120px;
+  flex-shrink: 0;
+  text-align: right;
+  color: var(--color-red);
+}
+
+.base-text-field.base-text-field--invalid .base-text-field__content {
+  border-color: var(--color-red);
+}
+
+.base-text-field__input[type='number']::-webkit-inner-spin-button,
+.base-text-field__input[type='number']::-webkit-outer-spin-button {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  margin: 0;
+}

--- a/src/components/BaseTextField/BaseTextField.tsx
+++ b/src/components/BaseTextField/BaseTextField.tsx
@@ -1,0 +1,75 @@
+import React, { useId, useState } from 'react';
+import './BaseTextField.css';
+import computeClassNames from '../../utils/compute-class-names';
+import { InputErrorMessage, isEmptyStr } from './utils/validator';
+
+type BaseTextFieldType = 'text' | 'number' | 'email' | 'password';
+
+interface BaseTextFieldProps {
+  id?: string;
+  label?: string;
+  onChange?(text: string): void;
+  required?: boolean;
+  value?: string;
+  placeholder?: string;
+  type?: BaseTextFieldType;
+}
+
+export default function BaseTextField({
+  id,
+  label = '',
+  onChange,
+  placeholder = '',
+  required = false,
+  value = '',
+  type = 'text'
+}: BaseTextFieldProps) {
+  const defaultId = useId();
+  const [isInvalid, setIsInvalid] = useState(false);
+  const [isInputFocused, setIsInputFocused] = useState(false);
+
+  const classNames = computeClassNames({
+    'base-text-field--invalid': isInvalid,
+    'base-text-field--focused': isInputFocused
+  });
+
+  function showInvalidState(currentInputValue: string) {
+    setIsInvalid(required && isEmptyStr(currentInputValue));
+  }
+
+  function handleChange(event: React.ChangeEvent<HTMLInputElement>) {
+    const inputValue = event.target.value.trim();
+    onChange?.(inputValue);
+    showInvalidState(inputValue);
+  }
+
+  function handleBlur() {
+    setIsInputFocused(false);
+    showInvalidState(value);
+  }
+
+  return (
+    <label className={`base-text-field ${classNames}`} htmlFor={id ?? defaultId}>
+      <div className="base-text-field__body">
+        {label && <h3 className="base-text-field__label">{label}</h3>}
+
+        <div className="base-text-field__content">
+          <input
+            className="base-text-field__input"
+            id={id ?? defaultId}
+            onBlur={handleBlur}
+            onChange={handleChange}
+            onFocus={() => setIsInputFocused(true)}
+            onInvalid={() => showInvalidState(value)}
+            placeholder={placeholder}
+            required={required}
+            type={type}
+            value={value}
+          />
+
+          {isInvalid && <p className="base-text-field__error">{InputErrorMessage.Empty}</p>}
+        </div>
+      </div>
+    </label>
+  );
+}

--- a/src/components/BaseTextField/index.ts
+++ b/src/components/BaseTextField/index.ts
@@ -1,0 +1,3 @@
+import BaseTextField from './BaseTextField';
+
+export default BaseTextField;

--- a/src/components/BaseTextField/utils/validator.ts
+++ b/src/components/BaseTextField/utils/validator.ts
@@ -1,0 +1,7 @@
+export enum InputErrorMessage {
+  Empty = "Can't be empty"
+}
+
+export function isEmptyStr(value: string): boolean {
+  return value.trim().length === 0;
+}


### PR DESCRIPTION
## Descripción:

Se requiere realizar el componente base para los campos de texto en la aplicacion.

## Cambios Realizados:

- Se crea el componente `BaseTextField` que recibe las siguientes propiedades:
```
  id?: string;
  label?: string;
  onChange?(text: string): void;
  required?: boolean;
  value?: string;
  placeholder?: string;
```


## Notas Adicionales:
Ejemplo de uso:

```
import { useState } from 'react';
import './App.css';
import BaseTextField from './components/BaseTextField';

function App() {
  const [text, setText] = useState('');

  return (
      <form>
        <BaseTextField onChange={setText} value={text} label="Text Field" required placeholder="e.g Make cofee" />
        <button type="submit">Submit</button>
      </form>
  );
}
```
![image](https://github.com/Hvasquezdev/kanban-task/assets/59294770/d87f81ab-54fe-4f50-8b59-2fdd1a3d5acf)