### PR TITLE
feat/CU-86a2ma91n: add board new column component

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,7 +1,12 @@
+import { useState } from 'react';
+import BaseModal from './components/BaseModal';
 import BoardColumnTask from './components/BoardColumnTask';
+import BoardNewColumn from './components/BoardNewColumn';
 import BaseLayout from './layouts/BaseLayout';
 
 function App() {
+  const [isOpen, setIsOpen] = useState(false);
+
   return (
     <BaseLayout>
       <div style={{ width: '30%', display: 'flex', flexDirection: 'column', gap: '1rem' }}>
@@ -9,8 +14,14 @@ function App() {
         <BoardColumnTask name="Figueron Engineer" subtasks={{ completed: 1, total: 5 }} />
         <BoardColumnTask name="Tite Design" subtasks={{ completed: 4, total: 5 }} />
         <BoardColumnTask name="Dito Python Frameworks" subtasks={{ completed: 5, total: 5 }} />
-      </div>
-    </BaseLayout>
+      </div> 
+
+      <BaseModal isOpen={isOpen} renderHeader={() => <h1>Header Testing</h1>} onClose={setIsOpen}>
+        <p>Modal Content</p>
+      </BaseModal>
+
+      <BoardNewColumn onClick={() => setIsOpen(!isOpen)} label="+ New column" />
+    </BaseLayout>   
   );
 }
 

--- a/src/assets/css/colors.css
+++ b/src/assets/css/colors.css
@@ -14,4 +14,5 @@
   --color-main-purple-o-25: #635fc740;
   --color-red: #ea5555;
   --color-red-hover: #ff9898;
+  --color-cloud-gray: #e9effa;
 }

--- a/src/components/BoardNewColumn/BoardNewColumn.css
+++ b/src/components/BoardNewColumn/BoardNewColumn.css
@@ -1,0 +1,19 @@
+.board-new-column {
+  width: 100%;
+  height: 100%;
+  background-color: var(--color-cloud-gray);
+
+  font-weight: bold;
+  border: none;
+  border-radius: 6px;
+  cursor: pointer;
+  transition: 0.3s ease;
+  padding: 1rem;
+}
+.board-new-column .board-new-column__label {
+  color: var(--color-medium-grey);
+}
+.board-new-column:hover .board-new-column__label {
+  transition: 0.3s ease;
+  color: var(--color-main-purple);
+}

--- a/src/components/BoardNewColumn/BoardNewColumn.tsx
+++ b/src/components/BoardNewColumn/BoardNewColumn.tsx
@@ -1,0 +1,19 @@
+import BaseHeading from '../BaseHeading';
+import './BoardNewColumn.css';
+
+interface BoardNewColumnProps {
+  onClick?: () => void;
+  label?: string;
+}
+
+function BoardNewColumn({ onClick, label = '' }: BoardNewColumnProps) {
+  return (
+    <button className="board-new-column" onClick={onClick}>
+      <BaseHeading variant="h6" size="xl" className="board-new-column__label" fontWeight="bold">
+        {label}
+      </BaseHeading>
+    </button>
+  );
+}
+
+export default BoardNewColumn;

--- a/src/components/BoardNewColumn/index.ts
+++ b/src/components/BoardNewColumn/index.ts
@@ -1,0 +1,3 @@
+import BoardNewColumn from './BoardNewColumn';
+
+export default BoardNewColumn;


### PR DESCRIPTION
## Descripción:

Componente para mostrar en la interfaz una columna vacia que al hacer click se debe abrir el modal para crear una columna en el board.

## Cambios Realizados:

- [x] Se agrego el componente BoardNewColumn
- [x] Se agrego prueba en el `app.tsx` 
![image](https://github.com/Hvasquezdev/kanban-task/assets/77895883/b594cdd9-f52e-471f-9cd2-8e3d53d180b2)


